### PR TITLE
incorrect path in test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can test whether the installation was successful by running the following:
 ```
 cd dopamine
 export PYTHONPATH=${PYTHONPATH}:.
-python tests/atari_init_test.py
+python tests/dopamine/atari_init_test.py
 ```
 
 The entry point to the standard Atari 2600 experiment is


### PR DESCRIPTION
the path is wrong in the command to run `atari_init_test.py`