### PR TITLE
Fix test module paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can test whether the installation was successful by running the following:
 ```
 cd dopamine
 export PYTHONPATH=${PYTHONPATH}:.
-python tests/atari_init_test.py
+python tests/dopamine/atari_init_test.py
 ```
 
 The entry point to the standard Atari 2600 experiment is
@@ -197,7 +197,7 @@ zlib (see "Install via source" above).
 From the root directory, tests can be run with a command such as:
 
 ```
-python -um tests.agents.rainbow.rainbow_agent_test
+python -um tests.dopamine.agents.rainbow.rainbow_agent_test
 ```
 
 ### References


### PR DESCRIPTION
Paths of `atari_init_test.py` and `rainbow_agent_test.py` are changed at these commits:

- `atari_init_test.py`
https://github.com/google/dopamine/commit/4eec4a84bba3474ceef41cfdbbffd2cbdeab5396#diff-06dd1af46472fdc9441b7d84d2cf2403

- `rainbow_agent_test.py`
https://github.com/google/dopamine/commit/4eec4a84bba3474ceef41cfdbbffd2cbdeab5396#diff-f840a06d8330e74b36dbb64f73be9267