### PR TITLE
Debug_Mode - Extended Documentation 

### DIFF
--- a/docs/api_docs/python/dqn_agent/DQNAgent.md
+++ b/docs/api_docs/python/dqn_agent/DQNAgent.md
@@ -62,7 +62,8 @@ Initializes the agent and constructs the components of its graph.
     checkpoints to keep.
 *   <b>`optimizer`</b>: `tf.train.Optimizer`, for training the value function.
 *   <b>`summary_writer`</b>: SummaryWriter object for outputting training
-    statistics. Summary writing disabled if set to None.
+    statistics. Summary writing disabled if set to None. In-iteration losses
+    will be only displayed in debug_mode.
 *   <b>`summary_writing_frequency`</b>: int, frequency with which summaries will
     be written. Lower values will result in slower training.
 

--- a/docs/api_docs/python/implicit_quantile_agent/ImplicitQuantileAgent.md
+++ b/docs/api_docs/python/implicit_quantile_agent/ImplicitQuantileAgent.md
@@ -52,7 +52,8 @@ values are taken from Dabney et al. (2018).
 *   <b>`double_dqn`</b>: boolean, whether to perform double DQN style learning
     as described in Van Hasselt et al.: https://arxiv.org/abs/1509.06461.
 *   <b>`summary_writer`</b>: SummaryWriter object for outputting training
-    statistics. Summary writing disabled if set to None.
+    statistics. Summary writing disabled if set to None. In-iteration losses
+    will be only displayed in debug_mode.
 *   <b>`summary_writing_frequency`</b>: int, frequency with which summaries will
     be written. Lower values will result in slower training.
 

--- a/docs/api_docs/python/rainbow_agent/RainbowAgent.md
+++ b/docs/api_docs/python/rainbow_agent/RainbowAgent.md
@@ -68,7 +68,8 @@ Initializes the agent and constructs the components of its graph.
     next training batch, speeding training up by about 30%.
 *   <b>`optimizer`</b>: `tf.train.Optimizer`, for training the value function.
 *   <b>`summary_writer`</b>: SummaryWriter object for outputting training
-    statistics. Summary writing disabled if set to None.
+    statistics. Summary writing disabled if set to None. In-iteration losses
+    will be only displayed in debug_mode.
 *   <b>`summary_writing_frequency`</b>: int, frequency with which summaries will
     be written. Lower values will result in slower training.
 

--- a/docs/api_docs/python/run_experiment/create_agent.md
+++ b/docs/api_docs/python/run_experiment/create_agent.md
@@ -23,7 +23,8 @@ Creates an agent.
     for in-agent training statistics in Tensorboard.
 *   <b>`debug_mode`</b>: bool, whether to output Tensorboard summaries. If set
     to true, the agent will output in-episode statistics to Tensorboard.
-    Disabled by default as this results in slower training.
+    Disabled by default as this results in slower training. The in-episode
+    statistics consists of in-iteration losses.
 
 #### Returns:
 

--- a/dopamine/agents/dqn/dqn_agent.py
+++ b/dopamine/agents/dqn/dqn_agent.py
@@ -304,6 +304,7 @@ class DQNAgent(object):
     loss = tf.losses.huber_loss(
         target, replay_chosen_q, reduction=tf.losses.Reduction.NONE)
     if self.summary_writer is not None:
+      # Runs only in the debug_mode
       with tf.variable_scope('Losses'):
         tf.summary.scalar('HuberLoss', tf.reduce_mean(loss))
     return self.optimizer.minimize(tf.reduce_mean(loss))

--- a/dopamine/agents/implicit_quantile/implicit_quantile_agent.py
+++ b/dopamine/agents/implicit_quantile/implicit_quantile_agent.py
@@ -317,6 +317,7 @@ class ImplicitQuantileAgent(rainbow_agent.RainbowAgent):
     update_priorities_op = tf.no_op()
     with tf.control_dependencies([update_priorities_op]):
       if self.summary_writer is not None:
+        # Runs only in the debug_mode
         with tf.variable_scope('Losses'):
           tf.summary.scalar('QuantileLoss', tf.reduce_mean(loss))
       return self.optimizer.minimize(tf.reduce_mean(loss)), tf.reduce_mean(loss)

--- a/dopamine/agents/rainbow/rainbow_agent.py
+++ b/dopamine/agents/rainbow/rainbow_agent.py
@@ -295,6 +295,7 @@ class RainbowAgent(dqn_agent.DQNAgent):
 
     with tf.control_dependencies([update_priorities_op]):
       if self.summary_writer is not None:
+        # Runs only in the debug_mode
         with tf.variable_scope('Losses'):
           tf.summary.scalar('CrossEntropyLoss', tf.reduce_mean(loss))
       # Schaul et al. reports a slightly different rule, where 1/N is also


### PR DESCRIPTION
Hello Dopamine Team,
While trying to build my own RL agent with the use of Dopamine, I struggled for few days to find out why the losses were not logged.  Back then I submitted an issue, but it was not answered for few weeks, until I realized that logging losses was buried in the debug_mode. That shows that It is not that straight forward for the Dopamine open-source community.  See issue #66 

Current Dopamine documentation is kind of secretive about logging losses, I hope this can help other researchers.

Thanks!

Edits:
* Adding a comment to agents about debug_mode
* Adding note about debug_mode to agents docs
* Adding further explanation to in-episode stats in create_agent doc