### PR TITLE
Adding automatic mixed precision training support

### DIFF
--- a/dopamine/agents/dqn/configs/dqn.gin
+++ b/dopamine/agents/dqn/configs/dqn.gin
@@ -1,7 +1,6 @@
 # Hyperparameters follow the classic Nature DQN, but we modify as necessary to
 # match those used in Rainbow (Hessel et al., 2018), to ensure apples-to-apples
 # comparison.
-import os
 import dopamine.discrete_domains.atari_lib
 import dopamine.discrete_domains.run_experiment
 import dopamine.agents.dqn.dqn_agent
@@ -17,11 +16,7 @@ DQNAgent.epsilon_train = 0.01
 DQNAgent.epsilon_eval = 0.001
 DQNAgent.epsilon_decay_period = 250000  # agent steps
 DQNAgent.tf_device = '/gpu:0'  # use '/cpu:*' for non-GPU version
-if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1':
-    optimizer = tf.train.RMSPropOptimizer()
-    DQNAgent.optimizer = @tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
-else:
-    DQNAgent.optimizer = @tf.train.RMSPropOptimizer()
+DQNAgent.optimizer = @tf.train.RMSPropOptimizer()
 
 tf.train.RMSPropOptimizer.learning_rate = 0.00025
 tf.train.RMSPropOptimizer.decay = 0.95

--- a/dopamine/agents/dqn/configs/dqn.gin
+++ b/dopamine/agents/dqn/configs/dqn.gin
@@ -1,6 +1,7 @@
 # Hyperparameters follow the classic Nature DQN, but we modify as necessary to
 # match those used in Rainbow (Hessel et al., 2018), to ensure apples-to-apples
 # comparison.
+import os
 import dopamine.discrete_domains.atari_lib
 import dopamine.discrete_domains.run_experiment
 import dopamine.agents.dqn.dqn_agent
@@ -16,7 +17,11 @@ DQNAgent.epsilon_train = 0.01
 DQNAgent.epsilon_eval = 0.001
 DQNAgent.epsilon_decay_period = 250000  # agent steps
 DQNAgent.tf_device = '/gpu:0'  # use '/cpu:*' for non-GPU version
-DQNAgent.optimizer = @tf.train.RMSPropOptimizer()
+if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1':
+    optimizer = tf.train.RMSPropOptimizer()
+    DQNAgent.optimizer = @tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
+else:
+    DQNAgent.optimizer = @tf.train.RMSPropOptimizer()
 
 tf.train.RMSPropOptimizer.learning_rate = 0.00025
 tf.train.RMSPropOptimizer.decay = 0.95

--- a/dopamine/agents/dqn/dqn_agent.py
+++ b/dopamine/agents/dqn/dqn_agent.py
@@ -181,6 +181,8 @@ class DQNAgent(object):
     self.eval_mode = eval_mode
     self.training_steps = 0
     self.optimizer = optimizer
+    if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1':
+        self.optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
     self.summary_writer = summary_writer
     self.summary_writing_frequency = summary_writing_frequency
     self.allow_partial_reload = allow_partial_reload

--- a/dopamine/agents/rainbow/rainbow_agent.py
+++ b/dopamine/agents/rainbow/rainbow_agent.py
@@ -38,7 +38,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-
+import os
 
 
 from dopamine.agents.dqn import dqn_agent
@@ -127,6 +127,8 @@ class RainbowAgent(dqn_agent.DQNAgent):
     self._replay_scheme = replay_scheme
     # TODO(b/110897128): Make agent optimizer attribute private.
     self.optimizer = optimizer
+    if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1':
+        self.optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
 
     dqn_agent.DQNAgent.__init__(
         self,


### PR DESCRIPTION
Automatic Mixed Precision training on GPU for Tensorflow has been recently introduced:

https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540

This PR adds GPU automatic mixed precision training to `dopamine`  via setting a single OS flag:
```
export TF_ENABLE_AUTO_MIXED_PRECISION=1
```