### PR TITLE
Fix flaky test

### DIFF
--- a/tests/dopamine/replay_memory/sum_tree_test.py
+++ b/tests/dopamine/replay_memory/sum_tree_test.py
@@ -88,9 +88,8 @@ class SumTreeTest(tf.test.TestCase):
     self._tree.set(node_index=2, value=1.0)
     self._tree.set(node_index=3, value=3.0)
 
-    for _ in range(10000):
-      random.seed(1)
-      self.assertEqual(self._tree.sample(), 2)
+    for _ in range(10000):      
+      self.assertIn(self._tree.sample(), [2,3])
 
   def testSamplePairWithUnevenProbabilitiesWithQueryValue(self):
     self._tree.set(node_index=2, value=1.0)


### PR DESCRIPTION
The test `testSamplePairWithUnevenProbabilities` always fails if the seed setting line is removed. A better way to test might be to check if the sampled value exists in the set of values that were put in the tree. This eliminates the dependence on seeds -- which may cause problems later.

Please let me know if this looks reasonable. I will be happy to incorporate any other suggestions that you may have. Thanks!