### PR TITLE
Preprocessing the state at the beginning of episode

### DIFF
--- a/dopamine/jax/agents/rainbow/rainbow_agent.py
+++ b/dopamine/jax/agents/rainbow/rainbow_agent.py
@@ -316,7 +316,7 @@ class JaxRainbowAgent(dqn_agent.JaxDQNAgent):
 
     self._rng, self.action = select_action(self.network_def,
                                            self.online_params,
-                                           self.state,
+                                           self.preprocess_fn(self.state),
                                            self._rng,
                                            self.num_actions,
                                            self.eval_mode,


### PR DESCRIPTION
It seems like preprocessing is missing at the beginning of episodes for the Jax Rainbow agent. Not sure how much it affects the results but it's a quick fix.