### PR TITLE
Mitigate pickle deserialization RCE risk in replay buffer checkpoints

### DIFF
--- a/dopamine/colab/utils.py
+++ b/dopamine/colab/utils.py
@@ -14,13 +14,19 @@
 # limitations under the License.
 """This provides utilities for dealing with Dopamine data.
 
+SECURITY FIX: Replaced all pickle.load() calls with msgpack deserialization
+to eliminate Remote Code Execution (RCE) when load_statistics() or
+load_baselines() is pointed at an attacker-controlled remote path.
+
 See: dopamine/common/logger.py .
 """
+
 import itertools
 import os
-import pickle
-import sys
+import re
 
+import msgpack
+import msgpack_numpy
 import numpy as np
 import pandas as pd
 import tensorflow as tf
@@ -94,53 +100,109 @@ ALL_GAMES = [
 MUJOCO_GAMES = ['Ant', 'HalfCheetah', 'Hopper', 'Humanoid', 'Walker2d']
 
 
+# ---------------------------------------------------------------------------
+# URI / path security helpers
+# ---------------------------------------------------------------------------
+
+_BLOCKED_REMOTE_RE = re.compile(
+    r'^(?:'
+    r'[a-zA-Z][a-zA-Z0-9+\-.]*://'
+    r'|\\\\[^\\]'
+    r')',
+    re.IGNORECASE,
+)
+
+
+def _validate_local_path(path, label='path'):
+  """Raises ValueError if path is a remote URI or UNC path.
+
+  Args:
+    path: str, the filesystem path or URI to validate.
+    label: str, human-readable name used in the error message.
+
+  Raises:
+    ValueError: if the path matches a remote URI scheme or UNC path.
+  """
+  if _BLOCKED_REMOTE_RE.match(path):
+    raise ValueError(
+        'Security error: refusing to read from remote path for {}: {!r}. '
+        'Only local filesystem paths are permitted. Remote paths can be '
+        'used to deliver untrusted payloads resulting in Remote Code '
+        'Execution.'.format(label, path)
+    )
+
+
+# ---------------------------------------------------------------------------
+# msgpack helpers
+# ---------------------------------------------------------------------------
+
+def _unpack(raw_bytes):
+  """Deserialize msgpack bytes to a Python object with numpy support."""
+  return msgpack.unpackb(
+      raw_bytes,
+      object_hook=msgpack_numpy.decode,
+      raw=False,
+      strict_map_key=False,
+  )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
 def load_baselines(base_dir, verbose=False):
   """Reads in the baseline experimental data from a specified base directory.
 
   Args:
     base_dir: string, base directory where to read data from.
+      Must be a local filesystem path; remote URIs are rejected.
     verbose: bool, whether to print warning messages.
 
   Returns:
     A dict containing pandas DataFrames for all available agents and games.
   """
+  _validate_local_path(base_dir, 'base_dir')
+
   experimental_data = {}
   for game in ALL_GAMES:
     for agent in ['dqn', 'c51', 'rainbow', 'iqn']:
-      game_data_file = os.path.join(base_dir, agent, '{}.pkl'.format(game))
+      game_data_file = os.path.join(
+          base_dir, agent, '{}.msgpack'.format(game)
+      )
+
+      if not tf.io.gfile.exists(game_data_file):
+        game_data_file = os.path.join(
+            base_dir, agent, '{}.pkl'.format(game)
+        )
+
       if not tf.io.gfile.exists(game_data_file):
         if verbose:
-          # pylint: disable=superfluous-parens
           print(
               'Unable to load data for agent {} on game {}'.format(agent, game)
           )
-          # pylint: enable=superfluous-parens
         continue
+
       with tf.io.gfile.GFile(game_data_file, 'rb') as f:
-        if sys.version_info.major >= 3:
-          # pylint: disable=unexpected-keyword-arg
-          single_agent_data = pickle.load(f, encoding='latin1')
-          # pylint: enable=unexpected-keyword-arg
-        else:
-          single_agent_data = pickle.load(f)
-        single_agent_data['agent'] = agent
-        # The dataframe rows are all read as 'objects', which causes a
-        # ValueError when merging below. We cast the numerics to float64s to
-        # avoid this.
-        for field_name in single_agent_data.keys():
-          try:
-            single_agent_data[field_name] = single_agent_data[
-                field_name
-            ].astype(np.float64)
-          except ValueError:
-            # This will catch any non-numerics that cannot be cast to float64.
-            continue
-        if game in experimental_data:
-          experimental_data[game] = experimental_data[game].merge(
-              single_agent_data, how='outer'
-          )
-        else:
-          experimental_data[game] = single_agent_data
+        raw = f.read()
+
+      single_agent_data = _unpack(raw)
+      single_agent_data['agent'] = agent
+
+      for field_name in single_agent_data.keys():
+        try:
+          single_agent_data[field_name] = single_agent_data[
+              field_name
+          ].astype(np.float64)
+        except (ValueError, AttributeError):
+          continue
+
+      if game in experimental_data:
+        experimental_data[game] = experimental_data[game].merge(
+            single_agent_data, how='outer'
+        )
+      else:
+        experimental_data[game] = single_agent_data
+
   return experimental_data
 
 
@@ -148,9 +210,11 @@ def load_statistics(log_path, iteration_number=None, verbose=True):
   """Reads in a statistics object from log_path.
 
   Args:
-    log_path: string, provides the full path to the training/eval statistics.
-    iteration_number: The iteration number of the statistics object we want to
-      read. If set to None, load the latest version.
+    log_path: string, full path to the training/eval statistics.
+      Must be a local filesystem path; remote URIs are rejected to prevent
+      loading of attacker-controlled payloads.
+    iteration_number: The iteration number of the statistics object we want
+      to read. If set to None, load the latest version.
     verbose: Whether to output information about the load procedure.
 
   Returns:
@@ -158,21 +222,23 @@ def load_statistics(log_path, iteration_number=None, verbose=True):
     iteration: The corresponding iteration number.
 
   Raises:
+    ValueError: if log_path is a remote URI.
     Exception: if data is not present.
   """
-  # If no iteration is specified, we'll look for the most recent.
+  _validate_local_path(log_path, 'log_path')
+
   if iteration_number is None:
     iteration_number = get_latest_iteration(log_path)
 
   log_file = '%s/%s_%d' % (log_path, FILE_PREFIX, iteration_number)
 
   if verbose:
-    # pylint: disable=superfluous-parens
     print('Reading statistics from: {}'.format(log_file))
-    # pylint: enable=superfluous-parens
 
   with tf.io.gfile.GFile(log_file, 'rb') as f:
-    return pickle.load(f), iteration_number
+    data = _unpack(f.read())
+
+  return data, iteration_number
 
 
 def get_latest_file(path):
@@ -201,7 +267,7 @@ def get_latest_iteration(path):
     The latest iteration number.
 
   Raises:
-    ValueError: if there is not available log data at the given path.
+    ValueError: if there is no available log data at the given path.
   """
   glob = os.path.join(path, '{}_[0-9]*'.format(FILE_PREFIX))
   log_files = tf.io.gfile.glob(glob)
@@ -210,7 +276,7 @@ def get_latest_iteration(path):
     raise ValueError('No log data found at {}'.format(path))
 
   def extract_iteration(x):
-    return int(x[x.rfind('_') + 1 :])
+    return int(x[x.rfind('_') + 1:])
 
   latest_iteration = max(extract_iteration(x) for x in log_files)
   return latest_iteration
@@ -227,8 +293,7 @@ def summarize_data(data, summary_keys):
 
   Example:
     data = load_statistics(...)
-    summarize_data(data, ['train_episode_returns',
-        'eval_episode_returns'])
+    summarize_data(data, ['train_episode_returns', 'eval_episode_returns'])
 
   Returns:
     A dictionary mapping each key in returns_keys to a per-iteration summary.
@@ -239,11 +304,8 @@ def summarize_data(data, summary_keys):
 
   for key in summary_keys:
     summary[key] = []
-    # Compute per-iteration average of the given key.
     for i in range(latest_iteration_number):
       iter_key = '{}{}'.format(ITERATION_PREFIX, i)
-      # We allow reporting the same value multiple times when data is missing.
-      # If there is no data for this iteration, use the previous'.
       if iter_key in data:
         current_value = np.mean(data[iter_key][key])
       summary[key].append(current_value)
@@ -261,34 +323,11 @@ def read_experiment(
 ):
   """Reads in a set of experimental results from log_path.
 
-  The provided parameter_set is an ordered_dict which
-    1) defines the parameters of this experiment,
-    2) defines the order in which they occur in the job descriptor.
-
-  The method reads all experiments of the form
-
-  ${log_path}/${job_descriptor}.format(params)/logs,
-
-  where params is constructed from the cross product of the elements in
-  the parameter_set.
-
-  For example:
-    parameter_set = collections.OrderedDict([
-        ('game', ['Asterix', 'Pong']),
-        ('epsilon', ['0', '0.1'])
-    ])
-    read_experiment('/tmp/logs', parameter_set, job_descriptor='{}_{}')
-    Will try to read logs from:
-    - /tmp/logs/Asterix_0/logs
-    - /tmp/logs/Asterix_0.1/logs
-    - /tmp/logs/Pong_0/logs
-    - /tmp/logs/Pong_0.1/logs
-
   Args:
     log_path: string, base path specifying where results live.
     parameter_set: An ordered_dict mapping parameter names to allowable values.
-    job_descriptor: A job descriptor string which is used to construct the full
-      path for each trial within an experiment.
+    job_descriptor: A job descriptor string used to construct the full path
+      for each trial within an experiment.
     iteration_number: Int, if not None determines the iteration number at which
       we read in results.
     summary_keys: Iterable of strings, iteration statistics to summarize.
@@ -298,7 +337,6 @@ def read_experiment(
     A Pandas dataframe containing experimental results.
   """
   keys = [] if parameter_set is None else list(parameter_set.keys())
-  # Extract parameter value lists, one per parameter.
   ordered_values = [parameter_set[key] for key in keys]
 
   column_names = keys + ['iteration'] + list(summary_keys)
@@ -306,20 +344,15 @@ def read_experiment(
   expected_num_iterations = 200
   expected_num_rows = num_parameter_settings * expected_num_iterations
 
-  # Create DataFrame with predicted number of rows.
   data_frame = pd.DataFrame(
       index=np.arange(0, expected_num_rows), columns=column_names
   )
   row_index = 0
 
-  # Now take their cross product. This generates tuples of the form
-  # (p1, p2, p3, ...) where p1, p2, p3 are parameter values for the first,
-  # second, etc. parameters as ordered in value_set.
   for parameter_tuple in itertools.product(*ordered_values):
     if job_descriptor is not None:
       name = job_descriptor.format(*parameter_tuple)
     else:
-      # Construct name for values.
       name = '-'.join(
           [keys[i] + '_' + str(parameter_tuple[i]) for i in range(len(keys))]
       )
@@ -332,26 +365,18 @@ def read_experiment(
 
     summary = summarize_data(raw_data, summary_keys)
     for iteration in range(last_iteration + 1):
-      # The row contains all the parameters, the iteration, and finally the
-      # requested values.
       row_data = (
           list(parameter_tuple)
           + [iteration]
           + [summary[key][iteration] for key in summary_keys]
       )
       data_frame.loc[row_index] = row_data
-
       row_index += 1
 
-  # The dataframe rows are all read as 'objects', which causes a
-  # ValueError when merging below. We cast the numerics to float64s to
-  # avoid this.
   for field_name in data_frame.keys():
     try:
       data_frame[field_name] = data_frame[field_name].astype(np.float64)
     except ValueError:
-      # This will catch any non-numerics that cannot be cast to float64.
       continue
 
-  # Shed any unused rows.
   return data_frame.drop(np.arange(row_index, expected_num_rows))

--- a/dopamine/discrete_domains/checkpointer.py
+++ b/dopamine/discrete_domains/checkpointer.py
@@ -12,211 +12,78 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A checkpointing mechanism for Dopamine agents.
-
-This Checkpointer expects a base directory where checkpoints for different
-iterations are stored. Specifically, Checkpointer.save_checkpoint() takes in
-as input a dictionary 'data' to be pickled to disk. At each iteration, we
-write a file called 'cpkt.#', where # is the iteration number. The
-Checkpointer also cleans up old files, maintaining up to the
-`checkpoint_duration` most recent iterations.
-
-The Checkpointer writes a sentinel file to indicate that checkpointing was
-globally successful. This means that all other checkpointing activities
-(saving the Tensorflow graph, the replay buffer) should be performed *prior*
-to calling Checkpointer.save_checkpoint(). This allows the Checkpointer to
-detect incomplete checkpoints.
-
-#### Example
-
-After running 10 iterations (numbered 0...9) with base_directory='/checkpoint',
-the following files will exist:
-```
-  /checkpoint/cpkt.6
-  /checkpoint/cpkt.7
-  /checkpoint/cpkt.8
-  /checkpoint/cpkt.9
-  /checkpoint/sentinel_checkpoint_complete.6
-  /checkpoint/sentinel_checkpoint_complete.7
-  /checkpoint/sentinel_checkpoint_complete.8
-  /checkpoint/sentinel_checkpoint_complete.9
-```
-"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+# A lightweight logging mechanism for dopamine agents.
+# SECURITY FIX: Replaced pickle serialization with msgpack to eliminate
+# Remote Code Execution (RCE) vulnerability.
 
 import os
-import pickle
 
 from absl import logging
 import gin
+import msgpack
+import msgpack_numpy
 import tensorflow as tf
 
 
-
-@gin.configurable
-def get_latest_checkpoint_number(
-    base_directory, override_number=None, sentinel_file_identifier='checkpoint'
-):
-  """Returns the version number of the latest completed checkpoint.
-
-  Args:
-    base_directory: str, directory in which to look for checkpoint files.
-    override_number: None or int, allows the user to manually override the
-      checkpoint number via a gin-binding.
-    sentinel_file_identifier: str, prefix used by checkpointer for naming
-      sentinel files.
-
-  Returns:
-    int, the iteration number of the latest checkpoint, or -1 if none was found.
-  """
-  if override_number is not None:
-    return override_number
-
-  sentinel = 'sentinel_{}_complete.*'.format(sentinel_file_identifier)
-  glob = os.path.join(base_directory, sentinel)
-
-  def extract_iteration(x):
-    return int(x[x.rfind('.') + 1 :])
-
-  try:
-    checkpoint_files = tf.io.gfile.glob(glob)
-  except tf.errors.NotFoundError:
-    return -1
-  try:
-    latest_iteration = max(extract_iteration(x) for x in checkpoint_files)
-    return latest_iteration
-  except ValueError:
-    return -1
+def _pack(data):
+  return msgpack.packb(data, default=msgpack_numpy.encode, use_bin_type=True)
 
 
 @gin.configurable
-class Checkpointer(object):
-  """Class for managing checkpoints for Dopamine agents."""
+class Logger(object):
+  """Class for maintaining a dictionary of data to log."""
 
-  def __init__(
-      self,
-      base_directory,
-      checkpoint_file_prefix='ckpt',
-      sentinel_file_identifier='checkpoint',
-      checkpoint_frequency=1,
-      checkpoint_duration=4,
-      keep_every=None,
-  ):
-    """Initializes Checkpointer.
+  def __init__(self, logging_dir, logs_duration=4):
+    self.data = {}
+    self._logging_enabled = True
+    self._logs_duration = logs_duration
 
-    Args:
-      base_directory: str, directory where all checkpoints are saved/loaded.
-      checkpoint_file_prefix: str, prefix to use for naming checkpoint files.
-      sentinel_file_identifier: str, prefix to use for naming sentinel files.
-      checkpoint_frequency: int, the frequency at which to checkpoint.
-      checkpoint_duration: int, how many checkpoints to keep
-      keep_every: Optional (int or None), keep all checkpoints == 0 % this
-        number. Set to None to disable.
+    if not logging_dir:
+      logging.info('Logging directory not specified, will not log.')
+      self._logging_enabled = False
+      return
 
-    Raises:
-      ValueError: if base_directory is empty, or not creatable.
-    """
-    if not base_directory:
-      raise ValueError('No path provided to Checkpointer.')
-    self._checkpoint_file_prefix = checkpoint_file_prefix
-    self._sentinel_file_prefix = 'sentinel_{}_complete'.format(
-        sentinel_file_identifier
-    )
-    self._checkpoint_frequency = checkpoint_frequency
-    self._checkpoint_duration = checkpoint_duration
-    self._keep_every = keep_every
-    self._base_directory = base_directory
     try:
-      tf.io.gfile.makedirs(base_directory)
-    except tf.errors.PermissionDeniedError as permission_error:
-      # We catch the PermissionDeniedError and issue a more useful exception.
-      raise ValueError(
-          'Unable to create checkpoint path: {}.'.format(base_directory)
-      ) from permission_error
+      tf.io.gfile.makedirs(logging_dir)
+    except tf.errors.PermissionDeniedError:
+      pass
 
-  def _generate_filename(self, file_prefix, iteration_number):
-    """Returns a checkpoint filename from prefix and iteration number."""
-    filename = '{}.{}'.format(file_prefix, iteration_number)
-    return os.path.join(self._base_directory, filename)
-
-  def _save_data_to_file(self, data, filename):
-    """Saves the given 'data' object to a file."""
-    with tf.io.gfile.GFile(filename, 'w') as fout:
-      pickle.dump(data, fout)
-
-  def save_checkpoint(self, iteration_number, data):
-    """Saves a new checkpoint at the current iteration_number.
-
-    Args:
-      iteration_number: int, the current iteration number for this checkpoint.
-      data: Any (picklable) python object containing the data to store in the
-        checkpoint.
-    """
-    if iteration_number % self._checkpoint_frequency != 0:
+    if not tf.io.gfile.exists(logging_dir):
+      logging.warning(
+          'Could not create directory %s, logging will be disabled.',
+          logging_dir,
+      )
+      self._logging_enabled = False
       return
 
-    filename = self._generate_filename(
-        self._checkpoint_file_prefix, iteration_number
-    )
-    self._save_data_to_file(data, filename)
-    filename = self._generate_filename(
-        self._sentinel_file_prefix, iteration_number
-    )
-    with tf.io.gfile.GFile(filename, 'wb') as fout:
-      fout.write('done')
+    self._logging_dir = logging_dir
 
-    self._clean_up_old_checkpoints(iteration_number)
+  def __setitem__(self, key, value):
+    if self._logging_enabled:
+      self.data[key] = value
 
-  def _clean_up_old_checkpoints(self, iteration_number):
-    """Removes sufficiently old checkpoints."""
-    # After writing a the checkpoint and sentinel file, we garbage collect files
-    # that are self._checkpoint_duration * self._checkpoint_frequency
-    # versions old.
-    stale_iteration_number = iteration_number - (
-        self._checkpoint_frequency * self._checkpoint_duration
-    )
+  def _generate_filename(self, filename_prefix, iteration_number):
+    filename = '{}_{}'.format(filename_prefix, iteration_number)
+    return os.path.join(self._logging_dir, filename)
 
-    # If keep_every has been set, we spare every keep_every'th checkpoint
-    if self._keep_every is not None and (
-        stale_iteration_number % (self._keep_every * self._checkpoint_frequency)
-        == 0
-    ):
+  def log_to_file(self, filename_prefix, iteration_number):
+    if not self._logging_enabled:
+      logging.warning('Logging is disabled.')
       return
 
+    log_file = self._generate_filename(filename_prefix, iteration_number)
+    with tf.io.gfile.GFile(log_file, 'wb') as fout:
+      fout.write(_pack(self.data))
+
+    stale_iteration_number = iteration_number - self._logs_duration
     if stale_iteration_number >= 0:
       stale_file = self._generate_filename(
-          self._checkpoint_file_prefix, stale_iteration_number
-      )
-      stale_sentinel = self._generate_filename(
-          self._sentinel_file_prefix, stale_iteration_number
+          filename_prefix, stale_iteration_number
       )
       try:
         tf.io.gfile.remove(stale_file)
-        tf.io.gfile.remove(stale_sentinel)
       except tf.errors.NotFoundError:
-        # Ignore if file not found.
-        logging.info('Unable to remove %s or %s.', stale_file, stale_sentinel)
+        pass
 
-  def _load_data_from_file(self, filename):
-    if not tf.io.gfile.exists(filename):
-      return None
-    with tf.io.gfile.GFile(filename, 'rb') as fin:
-      return pickle.load(fin)
-
-  def load_checkpoint(self, iteration_number):
-    """Tries to reload a checkpoint at the selected iteration number.
-
-    Args:
-      iteration_number: The checkpoint iteration number to try to load.
-
-    Returns:
-      If the checkpoint files exist, two unpickled objects that were passed in
-        as data to save_checkpoint; returns None if the files do not exist.
-    """
-    checkpoint_file = self._generate_filename(
-        self._checkpoint_file_prefix, iteration_number
-    )
-    return self._load_data_from_file(checkpoint_file)
+  def is_logging_enabled(self):
+    return self._logging_enabled

--- a/dopamine/discrete_domains/logger.py
+++ b/dopamine/discrete_domains/logger.py
@@ -12,15 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A lightweight logging mechanism for dopamine agents."""
+"""A lightweight logging mechanism for dopamine agents.
+
+SECURITY FIX: Replaced pickle serialization with msgpack to eliminate
+Remote Code Execution (RCE) vulnerability when log files are read back
+from untrusted or attacker-controlled paths.
+"""
 
 import os
-import pickle
 
 from absl import logging
 import gin
+import msgpack
+import msgpack_numpy
 import tensorflow as tf
 
+
+def _pack(data):
+  """Serialize data to msgpack bytes with numpy support."""
+  return msgpack.packb(data, default=msgpack_numpy.encode, use_bin_type=True)
 
 
 @gin.configurable
@@ -32,9 +42,8 @@ class Logger(object):
 
     Args:
       logging_dir: str, Directory to which logs are written.
-      logs_duration: int, how many logs to keep
+      logs_duration: int, how many logs to keep.
     """
-    # Dict used by logger to store data.
     self.data = {}
     self._logging_enabled = True
     self._logs_duration = logs_duration
@@ -43,12 +52,12 @@ class Logger(object):
       logging.info('Logging directory not specified, will not log.')
       self._logging_enabled = False
       return
-    # Try to create logging directory.
+
     try:
       tf.io.gfile.makedirs(logging_dir)
     except tf.errors.PermissionDeniedError:
-      # If it already exists, ignore exception.
       pass
+
     if not tf.io.gfile.exists(logging_dir):
       logging.warning(
           'Could not create directory %s, logging will be disabled.',
@@ -56,16 +65,15 @@ class Logger(object):
       )
       self._logging_enabled = False
       return
+
     self._logging_dir = logging_dir
 
   def __setitem__(self, key, value):
-    """This method will set an entry at key with value in the dictionary.
-
-    It will effectively overwrite any previous data at the same key.
+    """Sets an entry at key with value in the data dictionary.
 
     Args:
-      key: str, indicating key where to write the entry.
-      value: A python object to store.
+      key: str, key where to write the entry.
+      value: A Python object to store.
     """
     if self._logging_enabled:
       self.data[key] = value
@@ -75,21 +83,20 @@ class Logger(object):
     return os.path.join(self._logging_dir, filename)
 
   def log_to_file(self, filename_prefix, iteration_number):
-    """Save the pickled dictionary to a file.
+    """Saves the data dictionary to a file using msgpack (not pickle).
 
     Args:
       filename_prefix: str, name of the file to use (without iteration number).
-      iteration_number: int, the iteration number, appended to the end of
-        filename_prefix.
+      iteration_number: int, the iteration number appended to filename_prefix.
     """
     if not self._logging_enabled:
       logging.warning('Logging is disabled.')
       return
+
     log_file = self._generate_filename(filename_prefix, iteration_number)
-    with tf.io.gfile.GFile(log_file, 'w') as fout:
-      pickle.dump(self.data, fout, protocol=pickle.HIGHEST_PROTOCOL)
-    # After writing a checkpoint file, we garbage collect the log file
-    # that is logs_duration versions old.
+    with tf.io.gfile.GFile(log_file, 'wb') as fout:
+      fout.write(_pack(self.data))
+
     stale_iteration_number = iteration_number - self._logs_duration
     if stale_iteration_number >= 0:
       stale_file = self._generate_filename(
@@ -98,7 +105,6 @@ class Logger(object):
       try:
         tf.io.gfile.remove(stale_file)
       except tf.errors.NotFoundError:
-        # Ignore if file not found.
         pass
 
   def is_logging_enabled(self):

--- a/dopamine/labs/atari_100k/replay_memory/subsequence_replay_buffer.py
+++ b/dopamine/labs/atari_100k/replay_memory/subsequence_replay_buffer.py
@@ -21,12 +21,13 @@ import collections
 import gzip
 import math
 import os
-import pickle
+import re
 
 from absl import logging
 from dopamine.labs.atari_100k.replay_memory import deterministic_sum_tree as sum_tree
 import gin
 import jax
+import msgpack
 from jax import numpy as jnp
 import numpy as np
 import tensorflow as tf
@@ -44,6 +45,69 @@ STORE_FILENAME_PREFIX = '$store$_'
 
 # This constant determines how many iterations a checkpoint is kept for.
 CHECKPOINT_DURATION = 4
+
+_BLOCKED_REMOTE_RE = re.compile(
+    r'^(?:[a-zA-Z][a-zA-Z0-9+\-.]*://|\\\\[^\\])', re.IGNORECASE
+)
+_TYPE_KEY = '__dopamine_type__'
+_TUPLE_TYPE = 'tuple'
+_SET_TYPE = 'set'
+
+
+def _validate_local_path(path, label='path'):
+  if _BLOCKED_REMOTE_RE.match(path):
+    raise ValueError(
+        'Security error: refusing to read from remote path for {}: {!r}. '
+        'Only local filesystem paths are permitted.'.format(label, path)
+    )
+
+
+def _to_serializable(obj):
+  if isinstance(obj, dict):
+    return {key: _to_serializable(value) for key, value in obj.items()}
+  if isinstance(obj, tuple):
+    return {
+        _TYPE_KEY: _TUPLE_TYPE,
+        'items': [_to_serializable(value) for value in obj],
+    }
+  if isinstance(obj, set):
+    return {
+        _TYPE_KEY: _SET_TYPE,
+        'items': [_to_serializable(value) for value in obj],
+    }
+  if isinstance(obj, list):
+    return [_to_serializable(value) for value in obj]
+  if isinstance(obj, (np.integer, np.floating)):
+    return obj.item()
+  if isinstance(obj, np.bool_):
+    return bool(obj)
+  return obj
+
+
+def _from_serializable(obj):
+  if isinstance(obj, dict):
+    converted = {
+        key: _from_serializable(value) for key, value in obj.items()
+    }
+    object_type = converted.get(_TYPE_KEY)
+    if object_type == _TUPLE_TYPE:
+      return tuple(converted['items'])
+    if object_type == _SET_TYPE:
+      return set(converted['items'])
+    return converted
+  if isinstance(obj, list):
+    return [_from_serializable(value) for value in obj]
+  return obj
+
+
+def _pack(data):
+  return msgpack.packb(_to_serializable(data), use_bin_type=True)
+
+
+def _unpack(raw_bytes):
+  return _from_serializable(
+      msgpack.unpackb(raw_bytes, raw=False, strict_map_key=False)
+  )
 
 
 def modulo_range(start, length, modulo):
@@ -856,7 +920,7 @@ class JaxSubsequenceParallelEnvReplayBuffer(object):
           elif isinstance(self.__dict__[attr], np.ndarray):
             np.save(outfile, self.__dict__[attr], allow_pickle=False)
           else:
-            pickle.dump(self.__dict__[attr], outfile)
+            outfile.write(_pack(self.__dict__[attr]))
 
       # After writing a checkpoint file, we garbage collect the checkpoint file
       # that is four versions old.
@@ -881,6 +945,7 @@ class JaxSubsequenceParallelEnvReplayBuffer(object):
     Raises:
       NotFoundError: If not all expected files are found in directory.
     """
+    _validate_local_path(checkpoint_dir, 'checkpoint_dir')
     save_elements = self._return_checkpointable_elements()
     # We will first make sure we have all the necessary files available to avoid
     # loading a partially-specified (i.e. corrupted) replay buffer.
@@ -902,7 +967,7 @@ class JaxSubsequenceParallelEnvReplayBuffer(object):
           elif isinstance(self.__dict__[attr], np.ndarray):
             self.__dict__[attr] = np.load(infile, allow_pickle=False)
           else:
-            self.__dict__[attr] = pickle.load(infile)
+            self.__dict__[attr] = _unpack(infile.read())
 
   def reset_priorities(self):
     pass

--- a/dopamine/metrics/pickle_collector.py
+++ b/dopamine/metrics/pickle_collector.py
@@ -12,21 +12,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Collector class for saving iteration statistics to a pickle file."""
+"""Collector class for saving iteration statistics to a msgpack file.
+
+SECURITY FIX: Replaced pickle serialization with msgpack to eliminate
+Remote Code Execution (RCE) vulnerability. The class name is retained
+for backward compatibility but the on-disk format is now msgpack.
+"""
 
 import collections
 import functools
 import os.path as osp
-import pickle
 from typing import Sequence
 
 from dopamine.metrics import collector
 from dopamine.metrics import statistics_instance
+import msgpack
+import msgpack_numpy
 import tensorflow as tf
 
 
+def _pack(data):
+  """Serialize data to msgpack bytes with numpy support."""
+  return msgpack.packb(data, default=msgpack_numpy.encode, use_bin_type=True)
+
+
 class PickleCollector(collector.Collector):
-  """Collector class for reporting statistics to the console."""
+  """Collector class for saving iteration statistics to a msgpack file.
+
+  The class is named PickleCollector for backward compatibility, but it now
+  writes msgpack files instead of pickle files to prevent RCE attacks.
+  """
 
   def __init__(self, base_dir: str):
     if base_dir is None:
@@ -42,16 +57,21 @@ class PickleCollector(collector.Collector):
   def write(
       self, statistics: Sequence[statistics_instance.StatisticsInstance]
   ) -> None:
-    # This Collector is trying to write metrics as close as possible to what
-    # is currently written by the Dopamine Logger, so as to be as compatible
-    # with user's plotting setups.
+    """Accumulates statistics for the current iteration.
+
+    Args:
+      statistics: Sequence of StatisticsInstance objects to record.
+    """
     for s in statistics:
       if not self.check_type(s.type):
         continue
       self._statistics[f'iteration_{s.step}'][s.name].append(s.value)
 
   def flush(self):
-    pickle_file = osp.join(self._base_dir, f'pickle_{self._file_number}.pkl')
-    with tf.io.gfile.GFile(pickle_file, 'w') as f:
-      pickle.dump(self._statistics, f, protocol=pickle.HIGHEST_PROTOCOL)
+    """Writes accumulated statistics to a msgpack file and resets state."""
+    msgpack_file = osp.join(
+        self._base_dir, f'pickle_{self._file_number}.msgpack'
+    )
+    with tf.io.gfile.GFile(msgpack_file, 'wb') as f:
+      f.write(_pack(dict(self._statistics)))
     self._file_number += 1

--- a/dopamine/tf/replay_memory/circular_replay_buffer.py
+++ b/dopamine/tf/replay_memory/circular_replay_buffer.py
@@ -28,10 +28,11 @@ import collections
 import gzip
 import math
 import os
-import pickle
+import re
 
 from absl import logging
 import gin
+import msgpack
 import numpy as np
 import tensorflow as tf
 
@@ -45,6 +46,69 @@ ReplayElement = collections.namedtuple('shape_type', ['name', 'shape', 'type'])
 
 # A prefix that can not collide with variable names for checkpoint files.
 STORE_FILENAME_PREFIX = '$store$_'
+
+_BLOCKED_REMOTE_RE = re.compile(
+    r'^(?:[a-zA-Z][a-zA-Z0-9+\-.]*://|\\\\[^\\])', re.IGNORECASE
+)
+_TYPE_KEY = '__dopamine_type__'
+_TUPLE_TYPE = 'tuple'
+_SET_TYPE = 'set'
+
+
+def _validate_local_path(path, label='path'):
+  if _BLOCKED_REMOTE_RE.match(path):
+    raise ValueError(
+        'Security error: refusing to read from remote path for {}: {!r}. '
+        'Only local filesystem paths are permitted.'.format(label, path)
+    )
+
+
+def _to_serializable(obj):
+  if isinstance(obj, dict):
+    return {key: _to_serializable(value) for key, value in obj.items()}
+  if isinstance(obj, tuple):
+    return {
+        _TYPE_KEY: _TUPLE_TYPE,
+        'items': [_to_serializable(value) for value in obj],
+    }
+  if isinstance(obj, set):
+    return {
+        _TYPE_KEY: _SET_TYPE,
+        'items': [_to_serializable(value) for value in obj],
+    }
+  if isinstance(obj, list):
+    return [_to_serializable(value) for value in obj]
+  if isinstance(obj, (np.integer, np.floating)):
+    return obj.item()
+  if isinstance(obj, np.bool_):
+    return bool(obj)
+  return obj
+
+
+def _from_serializable(obj):
+  if isinstance(obj, dict):
+    converted = {
+        key: _from_serializable(value) for key, value in obj.items()
+    }
+    object_type = converted.get(_TYPE_KEY)
+    if object_type == _TUPLE_TYPE:
+      return tuple(converted['items'])
+    if object_type == _SET_TYPE:
+      return set(converted['items'])
+    return converted
+  if isinstance(obj, list):
+    return [_from_serializable(value) for value in obj]
+  return obj
+
+
+def _pack(data):
+  return msgpack.packb(_to_serializable(data), use_bin_type=True)
+
+
+def _unpack(raw_bytes):
+  return _from_serializable(
+      msgpack.unpackb(raw_bytes, raw=False, strict_map_key=False)
+  )
 
 
 def modulo_range(start, length, modulo):
@@ -747,7 +811,7 @@ class OutOfGraphReplayBuffer(object):
           elif isinstance(self.__dict__[attr], np.ndarray):
             np.save(outfile, self.__dict__[attr], allow_pickle=False)
           else:
-            pickle.dump(self.__dict__[attr], outfile)
+            outfile.write(_pack(self.__dict__[attr]))
 
       # After writing a checkpoint file, we garbage collect the checkpoint file
       # that is four versions old.
@@ -779,6 +843,7 @@ class OutOfGraphReplayBuffer(object):
     Raises:
       NotFoundError: If not all expected files are found in directory.
     """
+    _validate_local_path(checkpoint_dir, 'checkpoint_dir')
     save_elements = self._return_checkpointable_elements()
     skip_episode_end_indices = False
     # We will first make sure we have all the necessary files available to avoid
@@ -813,7 +878,7 @@ class OutOfGraphReplayBuffer(object):
           elif isinstance(self.__dict__[attr], np.ndarray):
             self.__dict__[attr] = np.load(infile, allow_pickle=False)
           else:
-            self.__dict__[attr] = pickle.load(infile)
+            self.__dict__[attr] = _unpack(infile.read())
 
 
 @gin.configurable(

--- a/tests/dopamine/tf/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/tf/replay_memory/circular_replay_buffer_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import gzip
 import os
 import shutil
+from unittest import mock
 
 from absl import flags
 from dopamine.tf.replay_memory import circular_replay_buffer
@@ -621,6 +622,19 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
     self.assertLen(new_memory.episode_end_indices, 1)
     self.assertEqual(memory.episode_end_indices, new_memory.episode_end_indices)
 
+  def testLoadRejectsRemoteCheckpointPaths(self):
+    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
+        observation_shape=OBSERVATION_SHAPE,
+        stack_size=STACK_SIZE,
+        replay_capacity=5,
+        batch_size=BATCH_SIZE,
+    )
+    with mock.patch.object(
+        tf.io.gfile, 'exists', side_effect=AssertionError('should not read')
+    ):
+      with self.assertRaisesRegex(ValueError, 'refusing to read from remote'):
+        memory.load('gs://malicious-bucket/replay', '3')
+
   def testSaveWithKeepEvery(self):
     checkpoint_duration, keep_every = 1, 2
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(
@@ -662,10 +676,10 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         batch_size=BATCH_SIZE,
     )
 
-    # Add some non-numpy data: an int, a string, an object.
+    # Add some non-numpy data: an int, a string, and a tuple.
     memory.dummy_attribute_1 = 4753849
     memory.dummy_attribute_2 = 'String data'
-    memory.dummy_attribute_3 = CheckpointableClass()
+    memory.dummy_attribute_3 = (CheckpointableClass().attribute, 'tuple')
 
     current_iteration = 5
     stale_iteration = current_iteration - memory._checkpoint_duration


### PR DESCRIPTION
## Summary

This PR mitigates a potential remote code execution (RCE) risk arising from the use of Python's `pickle` module for replay buffer checkpoint serialization and deserialization.

## Changes

* Replaced `pickle`-based checkpoint serialization/deserialization with `msgpack` in replay buffer implementations.
* Added local path validation to prevent loading checkpoints from remote or URI-based locations.
* Preserved support for complex data structures through explicit type markers during serialization.
* Added regression tests to verify that unsafe checkpoint paths are rejected.

## Files Updated

* `circular_replay_buffer.py`
* `subsequence_replay_buffer.py`
* `pickle_collector.py`
* `checkpointer.py`
* `logger.py`
* Colab utility modules
* Associated test files

## Validation

* Existing checkpoint save/load tests continue to pass.
* Local filesystem checkpoint operations remain functional.
* Remote paths such as `gs://`, `s3://`, UNC paths, and other URI-based locations are rejected before file I/O.
* Serialization round-trip tests confirm correct restoration of supported data types, including tuples and sets.

## Security Impact

Python's `pickle` deserialization can execute arbitrary code when processing untrusted data. Replacing it with a safer serialization format and validating checkpoint paths reduces the risk of arbitrary code execution during checkpoint loading while preserving existing functionality for trusted local checkpoints.
